### PR TITLE
feat: add CLI agent adapters for opencode, codex, and claude

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# gesttalt
+
+`gesttalt` is an open-source, Rust-native **agentic coding environment**. It hosts
+multiple coding agents inside a single workspace and lets you drive them, compare
+them, and orchestrate them against the same project — without leaving the editor.
+
+## What it is
+
+- A desktop application built in Rust on top of [GPUI], the same UI toolkit that
+  powers the [Zed] editor. We deliberately follow Zed's UI patterns (workspace
+  with title bar, docks, status bar, command palette) so the experience feels
+  immediately familiar to anyone coming from Zed.
+- A first-class home for **CLI coding agents**. We treat agents like `claude`,
+  `codex`, and `opencode` as pluggable backends: each one is detected, queried
+  for available models and reasoning levels, and driven over its JSON event
+  stream from inside the app.
+- Tightly integrated with [`fabrik`][fabrik], our fast build system, so the agent
+  loop (edit → build → test → diagnose) runs against incremental, cache-aware
+  builds rather than full rebuilds. Fabrik is a first-party dependency, not a
+  third-party plugin.
+
+## What it is not
+
+- Not a fork of Zed. We borrow GPUI and the workspace patterns, but the product
+  is its own thing: agent orchestration first, editing second.
+- Not tied to any single agent vendor. Adding a new CLI agent is a matter of
+  writing a small adapter (see `crates/agents`).
+
+## Repo layout
+
+```
+crates/
+  gesttalt/   desktop app (GPUI workspace, docks, title bar, status bar)
+  agents/     adapters for CLI coding agents (claude, codex, opencode)
+              + the `agents-probe` binary that exercises them end to end
+```
+
+## Working on the project
+
+- Toolchain is pinned via `mise.toml` (Rust 1.95, minimal profile + clippy +
+  rustfmt + rust-analyzer + rust-src). Run `mise install` once.
+- Build: `cargo build`. Run the desktop app: `cargo run -p gesttalt`.
+- Probe the locally installed coding-agent CLIs: `cargo run -p agents --bin agents-probe`.
+  This will detect each of `opencode`, `codex`, `claude` on `PATH`, list the
+  models they expose, list their reasoning levels, and send a tiny prompt to
+  each so you can see live JSON event output.
+
+## Conventions
+
+- Edition 2024, workspace-level lints (see root `Cargo.toml`).
+- Keep adapters in `crates/agents` free of GPUI dependencies — they must be
+  reusable from headless tools (CI, scripts, the probe binary) as well as the
+  desktop app.
+- New CLI agent? Implement the `AgentCLI` trait in a new module under
+  `crates/agents/src/` and register it in `crates/agents/src/lib.rs::all()`.
+
+[GPUI]: https://www.gpui.rs/
+[Zed]: https://zed.dev/
+[fabrik]: https://github.com/tuist/fabrik

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "agents"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "which 8.0.2",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,7 +2344,7 @@ dependencies = [
  "tendril",
  "unicase",
  "walkdir",
- "which",
+ "which 6.0.3",
 ]
 
 [[package]]
@@ -6183,6 +6196,15 @@ dependencies = [
  "home",
  "rustix 0.38.44",
  "winsafe",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/gesttalt"]
+members = ["crates/gesttalt", "crates/agents"]
 default-members = ["crates/gesttalt"]
 
 [workspace.package]
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 gesttalt = { path = "crates/gesttalt" }
+agents = { path = "crates/agents" }
 
 gpui = "0.2.2"
 anyhow = "1.0"
@@ -18,6 +19,8 @@ log = "0.4"
 env_logger = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "2.0"
+which = "8.0"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "allow" }

--- a/crates/agents/Cargo.toml
+++ b/crates/agents/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "agents"
+description = "Adapters for CLI coding agents (claude, codex, opencode) used by gesttalt."
+edition.workspace = true
+version.workspace = true
+publish.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "agents-probe"
+path = "src/bin/agents-probe.rs"
+
+[dependencies]
+anyhow.workspace = true
+env_logger.workspace = true
+log.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+which.workspace = true

--- a/crates/agents/src/bin/agents-probe.rs
+++ b/crates/agents/src/bin/agents-probe.rs
@@ -1,0 +1,178 @@
+//! End-to-end probe for the CLI agent adapters.
+//!
+//! For each agent we know about: detect it, list its models, list its
+//! reasoning levels, and send a tiny prompt to verify the JSON event stream
+//! parses. Output is plain text, formatted for a terminal.
+//!
+//! Usage:
+//!     cargo run -p agents --bin agents-probe
+//!     cargo run -p agents --bin agents-probe -- --no-session
+//!     cargo run -p agents --bin agents-probe -- --only opencode
+//!     cargo run -p agents --bin agents-probe -- --prompt "what is 2+2?"
+
+use std::io::Write;
+use std::process::ExitCode;
+
+use agents::{AgentCLI, SessionEvent, SessionRequest};
+
+struct Args {
+    no_session: bool,
+    only: Option<String>,
+    prompt: String,
+}
+
+fn parse_args() -> Args {
+    let mut args = Args {
+        no_session: false,
+        only: None,
+        prompt: "Reply with exactly the words: probe ok.".to_string(),
+    };
+    let mut iter = std::env::args().skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--no-session" => args.no_session = true,
+            "--only" => args.only = iter.next(),
+            "--prompt" => {
+                if let Some(p) = iter.next() {
+                    args.prompt = p;
+                }
+            }
+            "-h" | "--help" => {
+                println!("agents-probe [--no-session] [--only NAME] [--prompt TEXT]");
+                std::process::exit(0);
+            }
+            _ => {
+                eprintln!("unknown argument: {arg}");
+                std::process::exit(2);
+            }
+        }
+    }
+    args
+}
+
+fn main() -> ExitCode {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format_target(false)
+        .init();
+    let args = parse_args();
+
+    let mut any_failed = false;
+    for adapter in agents::all() {
+        let kind = adapter.kind();
+        if let Some(only) = &args.only {
+            if only != kind.as_str() {
+                continue;
+            }
+        }
+        section(&format!("== {} ==", kind));
+
+        let info = match adapter.detect() {
+            Ok(Some(info)) => info,
+            Ok(None) => {
+                println!("  (not installed on PATH; skipping)");
+                continue;
+            }
+            Err(err) => {
+                println!("  detect failed: {err}");
+                any_failed = true;
+                continue;
+            }
+        };
+        println!("  binary:  {}", info.executable.display());
+        println!("  version: {}", info.version);
+
+        match adapter.list_models() {
+            Ok(models) => {
+                println!("  models ({}):", models.len());
+                for m in models.iter().take(10) {
+                    let alias = m
+                        .alias
+                        .as_deref()
+                        .map(|a| format!(" (alias: {a})"))
+                        .unwrap_or_default();
+                    println!("    - {} [{}]{alias}", m.id, m.provider);
+                }
+                if models.len() > 10 {
+                    println!("    ... {} more", models.len() - 10);
+                }
+            }
+            Err(err) => {
+                println!("  list_models failed: {err}");
+                any_failed = true;
+            }
+        }
+
+        let efforts = adapter.reasoning_efforts();
+        let pretty: Vec<_> = efforts.iter().map(|e| e.to_string()).collect();
+        println!("  thinking levels: {}", pretty.join(", "));
+
+        if args.no_session {
+            continue;
+        }
+
+        if let Err(err) = run_probe_session(&*adapter, &args.prompt) {
+            println!("  session failed: {err}");
+            any_failed = true;
+        }
+    }
+
+    if any_failed {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+fn section(title: &str) {
+    println!();
+    println!("{title}");
+}
+
+fn run_probe_session(adapter: &dyn AgentCLI, prompt: &str) -> agents::Result<()> {
+    println!("  session: sending probe prompt …");
+    let req = SessionRequest::new(prompt);
+    let mut text_chars = 0usize;
+    let mut reasoning_chars = 0usize;
+    let mut tool_calls = 0usize;
+    let mut session_id = None;
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+
+    let mut on_event = |event: &SessionEvent| match event {
+        SessionEvent::SessionStarted { session_id: id } => {
+            session_id = Some(id.clone());
+            let _ = writeln!(handle, "    [session] {id}");
+        }
+        SessionEvent::AssistantText { text } => {
+            text_chars += text.len();
+            let _ = write!(handle, "{text}");
+            let _ = handle.flush();
+        }
+        SessionEvent::Reasoning { text } => {
+            reasoning_chars += text.len();
+        }
+        SessionEvent::ToolUse { name, .. } => {
+            tool_calls += 1;
+            let _ = writeln!(handle, "\n    [tool] {name}");
+        }
+        SessionEvent::Done { .. } | SessionEvent::Raw { .. } => {}
+    };
+
+    let result = adapter.run_session(&req, &mut on_event)?;
+    println!();
+    println!(
+        "  done: text={}B reasoning={}B tool_calls={} session_id={}",
+        text_chars,
+        reasoning_chars,
+        tool_calls,
+        session_id
+            .as_deref()
+            .or(result.session_id.as_deref())
+            .unwrap_or("<none>")
+    );
+    if let Some(text) = result.final_text.as_deref() {
+        let preview = text.chars().take(120).collect::<String>();
+        println!("  final:  {preview:?}");
+    }
+    Ok(())
+}

--- a/crates/agents/src/bin/agents-probe.rs
+++ b/crates/agents/src/bin/agents-probe.rs
@@ -134,14 +134,14 @@ fn run_probe_session(adapter: &dyn AgentCLI, prompt: &str) -> agents::Result<()>
     let mut text_chars = 0usize;
     let mut reasoning_chars = 0usize;
     let mut tool_calls = 0usize;
-    let mut session_id = None;
+    let mut started = false;
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
 
     let mut on_event = |event: &SessionEvent| match event {
-        SessionEvent::SessionStarted { session_id: id } => {
-            session_id = Some(id.clone());
-            let _ = writeln!(handle, "    [session] {id}");
+        SessionEvent::SessionStarted { .. } => {
+            started = true;
+            let _ = writeln!(handle, "    [session-started]");
         }
         SessionEvent::AssistantText { text } => {
             text_chars += text.len();
@@ -160,15 +160,13 @@ fn run_probe_session(adapter: &dyn AgentCLI, prompt: &str) -> agents::Result<()>
 
     let result = adapter.run_session(&req, &mut on_event)?;
     println!();
+    let _ = started;
     println!(
-        "  done: text={}B reasoning={}B tool_calls={} session_id={}",
+        "  done: text={}B reasoning={}B tool_calls={} got_session={}",
         text_chars,
         reasoning_chars,
         tool_calls,
-        session_id
-            .as_deref()
-            .or(result.session_id.as_deref())
-            .unwrap_or("<none>")
+        result.session_id.is_some(),
     );
     if let Some(text) = result.final_text.as_deref() {
         let preview = text.chars().take(120).collect::<String>();

--- a/crates/agents/src/claude.rs
+++ b/crates/agents/src/claude.rs
@@ -1,0 +1,257 @@
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
+
+use crate::detect::detect_with;
+use crate::types::{
+    AgentCLI, AgentInfo, AgentKind, Error, Model, ReasoningEffort, Result, SessionEvent,
+    SessionRequest, SessionResult,
+};
+
+/// Adapter for Anthropic's `claude` CLI (Claude Code).
+///
+/// Claude does not expose a `models` subcommand: the CLI accepts model aliases
+/// (`sonnet`, `opus`, `haiku`) and full names (`claude-sonnet-4-6`, etc.). We
+/// surface the documented aliases plus the latest known full names; users can
+/// pass any string to `--model`.
+///
+/// Driving model: `claude --print --model <m> --effort <e> --output-format
+/// stream-json --verbose --include-partial-messages "prompt"`. The stream-json
+/// output is the same wire format the SDK speaks: `system/init`, `stream_event`
+/// (with nested `content_block_delta` etc.), and a terminal `result` line.
+pub struct Claude;
+
+impl Claude {
+    pub fn new() -> Self {
+        Self
+    }
+
+    const BIN: &'static str = "claude";
+}
+
+impl Default for Claude {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const KNOWN_MODELS: &[(&str, Option<&str>)] = &[
+    ("claude-opus-4-7", Some("opus")),
+    ("claude-sonnet-4-6", Some("sonnet")),
+    ("claude-haiku-4-5-20251001", Some("haiku")),
+];
+
+impl AgentCLI for Claude {
+    fn kind(&self) -> AgentKind {
+        AgentKind::Claude
+    }
+
+    fn detect(&self) -> Result<Option<AgentInfo>> {
+        detect_with(AgentKind::Claude, Self::BIN, &["--version"], |s| {
+            // `claude --version` prints e.g. "2.1.131 (Claude Code)".
+            s.split_whitespace()
+                .next()
+                .unwrap_or(s.trim())
+                .to_string()
+        })
+    }
+
+    fn list_models(&self) -> Result<Vec<Model>> {
+        Ok(KNOWN_MODELS
+            .iter()
+            .map(|(id, alias)| Model {
+                id: (*id).to_string(),
+                alias: alias.map(|a| a.to_string()),
+                provider: "anthropic".to_string(),
+                supports_reasoning: true,
+            })
+            .collect())
+    }
+
+    fn reasoning_efforts(&self) -> Vec<ReasoningEffort> {
+        // From `claude --help`: `--effort <level>` accepts low, medium, high,
+        // xhigh, max.
+        vec![
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::XHigh,
+            ReasoningEffort::Max,
+        ]
+    }
+
+    fn run_session(
+        &self,
+        req: &SessionRequest,
+        on_event: &mut dyn FnMut(&SessionEvent),
+    ) -> Result<SessionResult> {
+        let mut cmd = Command::new(Self::BIN);
+        cmd.arg("--print")
+            .arg("--output-format")
+            .arg("stream-json")
+            .arg("--verbose")
+            // Without this, claude only emits one consolidated `assistant`
+            // line per turn, no `content_block_delta` events. We want
+            // per-token deltas so the UI can stream output as it arrives.
+            .arg("--include-partial-messages");
+        if let Some(model) = &req.model {
+            cmd.arg("--model").arg(model);
+        }
+        if let Some(effort) = req.effort {
+            cmd.arg("--effort").arg(effort.as_str());
+        }
+        if let Some(cwd) = &req.cwd {
+            cmd.current_dir(cwd);
+        }
+        cmd.arg(&req.prompt);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(|source| Error::Spawn {
+            cmd: format!("{} --print", Self::BIN),
+            source,
+        })?;
+        let stdout = child.stdout.take().expect("stdout was piped");
+        let reader = BufReader::new(stdout);
+
+        let mut result = SessionResult::default();
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value: Value = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            for event in parse_event(&value) {
+                collect(&event, &mut result);
+                on_event(&event);
+                result.events.push(event);
+            }
+        }
+
+        let status = child.wait()?;
+        if !status.success() {
+            let stderr = child
+                .stderr
+                .take()
+                .map(|mut s| {
+                    let mut buf = String::new();
+                    let _ = std::io::Read::read_to_string(&mut s, &mut buf);
+                    buf
+                })
+                .unwrap_or_default();
+            return Err(Error::NonZeroExit {
+                cmd: format!("{} --print", Self::BIN),
+                status: status.code().unwrap_or(-1),
+                stderr,
+            });
+        }
+        Ok(result)
+    }
+}
+
+fn parse_event(value: &Value) -> Vec<SessionEvent> {
+    let ty = value.get("type").and_then(Value::as_str).unwrap_or("");
+    match ty {
+        "system" => {
+            if value.get("subtype").and_then(Value::as_str) == Some("init") {
+                if let Some(session_id) = value.get("session_id").and_then(Value::as_str) {
+                    return vec![SessionEvent::SessionStarted {
+                        session_id: session_id.to_string(),
+                    }];
+                }
+            }
+            Vec::new()
+        }
+        "stream_event" => {
+            let inner = match value.get("event") {
+                Some(v) => v,
+                None => return Vec::new(),
+            };
+            parse_stream_inner(inner)
+        }
+        "result" => {
+            let text = value
+                .get("result")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let usage = value.get("usage").cloned();
+            vec![SessionEvent::Done { text, usage }]
+        }
+        // The non-streaming `assistant` summary line duplicates content we
+        // already emitted via stream_event deltas; ignore it.
+        _ => Vec::new(),
+    }
+}
+
+fn parse_stream_inner(event: &Value) -> Vec<SessionEvent> {
+    let ty = event.get("type").and_then(Value::as_str).unwrap_or("");
+    match ty {
+        "content_block_delta" => {
+            let delta = match event.get("delta") {
+                Some(v) => v,
+                None => return Vec::new(),
+            };
+            let dty = delta.get("type").and_then(Value::as_str).unwrap_or("");
+            match dty {
+                "text_delta" => {
+                    let text = delta
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    vec![SessionEvent::AssistantText { text }]
+                }
+                "thinking_delta" => {
+                    let text = delta
+                        .get("thinking")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    vec![SessionEvent::Reasoning { text }]
+                }
+                _ => Vec::new(),
+            }
+        }
+        "content_block_start" => {
+            let block = match event.get("content_block") {
+                Some(v) => v,
+                None => return Vec::new(),
+            };
+            let bty = block.get("type").and_then(Value::as_str).unwrap_or("");
+            if bty == "tool_use" {
+                let name = block
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("tool")
+                    .to_string();
+                let input = block.get("input").cloned().unwrap_or(Value::Null);
+                return vec![SessionEvent::ToolUse { name, input }];
+            }
+            Vec::new()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn collect(event: &SessionEvent, into: &mut SessionResult) {
+    match event {
+        SessionEvent::SessionStarted { session_id } => {
+            into.session_id = Some(session_id.clone());
+        }
+        SessionEvent::AssistantText { text } => match &mut into.final_text {
+            Some(existing) => existing.push_str(text),
+            None => into.final_text = Some(text.clone()),
+        },
+        SessionEvent::Done { text: Some(t), .. } => {
+            // The terminal `result` line carries the consolidated final text;
+            // prefer it over our delta accumulation if we have it.
+            into.final_text = Some(t.clone());
+        }
+        _ => {}
+    }
+}

--- a/crates/agents/src/codex.rs
+++ b/crates/agents/src/codex.rs
@@ -1,0 +1,280 @@
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
+
+use crate::detect::detect_with;
+use crate::types::{
+    AgentCLI, AgentInfo, AgentKind, Error, Model, ReasoningEffort, Result, SessionEvent,
+    SessionRequest, SessionResult,
+};
+
+/// Adapter for OpenAI's `codex` CLI.
+///
+/// Codex does not expose a `models` subcommand: the model is configured in
+/// `~/.codex/config.toml` and selected via `-m`. We therefore surface a small
+/// curated set of well-known models plus whatever the user has configured as
+/// their default. Users can pass any model id at runtime — the curated list
+/// is just for UX.
+///
+/// Driving model: `codex exec --json -m <model> -c model_reasoning_effort=<effort>
+/// --skip-git-repo-check "prompt"`. JSONL events on stdout look like
+/// `{"type":"thread.started",...}`, `{"type":"item.completed", "item":{...}}`,
+/// `{"type":"turn.completed", "usage":{...}}`.
+pub struct Codex;
+
+impl Codex {
+    pub fn new() -> Self {
+        Self
+    }
+
+    const BIN: &'static str = "codex";
+}
+
+impl Default for Codex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Curated list of models that codex is known to ship support for as of the
+/// 0.128.x line. We keep this small — codex itself accepts any string and the
+/// user's `config.toml` may name something else.
+const CURATED_MODELS: &[&str] = &[
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex",
+    "gpt-5.2-codex",
+    "gpt-5.1-codex",
+    "gpt-5.1-codex-mini",
+    "gpt-5-codex",
+];
+
+impl AgentCLI for Codex {
+    fn kind(&self) -> AgentKind {
+        AgentKind::Codex
+    }
+
+    fn detect(&self) -> Result<Option<AgentInfo>> {
+        detect_with(AgentKind::Codex, Self::BIN, &["--version"], |s| {
+            // `codex --version` prints e.g. "codex-cli 0.128.0".
+            s.split_whitespace()
+                .last()
+                .unwrap_or(s.trim())
+                .to_string()
+        })
+    }
+
+    fn list_models(&self) -> Result<Vec<Model>> {
+        let mut out: Vec<Model> = CURATED_MODELS
+            .iter()
+            .map(|id| Model {
+                id: (*id).to_string(),
+                alias: None,
+                provider: "openai".to_string(),
+                supports_reasoning: true,
+            })
+            .collect();
+
+        // Best-effort: include the user's configured default model if it is
+        // not already in the curated list. We parse a minimal subset of TOML
+        // (top-level `model = "..."`) by hand to avoid a TOML dep.
+        if let Some(home) = std::env::var_os("HOME") {
+            let path = std::path::Path::new(&home).join(".codex/config.toml");
+            if let Ok(contents) = std::fs::read_to_string(&path) {
+                if let Some(model) = extract_top_level_string(&contents, "model") {
+                    if !out.iter().any(|m| m.id == model) {
+                        out.insert(
+                            0,
+                            Model {
+                                id: model,
+                                alias: Some("configured-default".into()),
+                                provider: "openai".into(),
+                                supports_reasoning: true,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    fn reasoning_efforts(&self) -> Vec<ReasoningEffort> {
+        // Discovered empirically from codex's error message:
+        // "expected one of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`".
+        vec![
+            ReasoningEffort::None,
+            ReasoningEffort::Minimal,
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::XHigh,
+        ]
+    }
+
+    fn run_session(
+        &self,
+        req: &SessionRequest,
+        on_event: &mut dyn FnMut(&SessionEvent),
+    ) -> Result<SessionResult> {
+        let mut cmd = Command::new(Self::BIN);
+        cmd.arg("exec").arg("--json").arg("--skip-git-repo-check");
+        if let Some(model) = &req.model {
+            cmd.arg("-m").arg(model);
+        }
+        if let Some(effort) = req.effort {
+            cmd.arg("-c")
+                .arg(format!("model_reasoning_effort=\"{}\"", effort.as_str()));
+        }
+        if let Some(cwd) = &req.cwd {
+            cmd.arg("-C").arg(cwd);
+        }
+        cmd.arg(&req.prompt);
+        // Detach stdin so codex doesn't try to read additional input from a
+        // piped parent process.
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(|source| Error::Spawn {
+            cmd: format!("{} exec", Self::BIN),
+            source,
+        })?;
+        let stdout = child.stdout.take().expect("stdout was piped");
+        let reader = BufReader::new(stdout);
+
+        let mut result = SessionResult::default();
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value: Value = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let event = parse_event(&value);
+            collect(&event, &mut result);
+            on_event(&event);
+            result.events.push(event);
+        }
+
+        let status = child.wait()?;
+        if !status.success() {
+            let stderr = child
+                .stderr
+                .take()
+                .map(|mut s| {
+                    let mut buf = String::new();
+                    let _ = std::io::Read::read_to_string(&mut s, &mut buf);
+                    buf
+                })
+                .unwrap_or_default();
+            return Err(Error::NonZeroExit {
+                cmd: format!("{} exec", Self::BIN),
+                status: status.code().unwrap_or(-1),
+                stderr,
+            });
+        }
+        Ok(result)
+    }
+}
+
+fn parse_event(value: &Value) -> SessionEvent {
+    let ty = value.get("type").and_then(Value::as_str).unwrap_or("");
+    match ty {
+        "thread.started" => {
+            let session_id = value
+                .get("thread_id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            SessionEvent::SessionStarted { session_id }
+        }
+        "item.completed" | "item.updated" => {
+            let item = value.get("item");
+            let item_type = item
+                .and_then(|i| i.get("type"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            match item_type {
+                "agent_message" => {
+                    let text = item
+                        .and_then(|i| i.get("text"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    SessionEvent::AssistantText { text }
+                }
+                "reasoning" => {
+                    let text = item
+                        .and_then(|i| i.get("text"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    SessionEvent::Reasoning { text }
+                }
+                "command_execution" | "tool_call" | "function_call" => {
+                    let name = item
+                        .and_then(|i| i.get("name"))
+                        .and_then(Value::as_str)
+                        .unwrap_or(item_type)
+                        .to_string();
+                    let input = item
+                        .and_then(|i| i.get("arguments"))
+                        .cloned()
+                        .or_else(|| item.and_then(|i| i.get("command")).cloned())
+                        .unwrap_or(Value::Null);
+                    SessionEvent::ToolUse { name, input }
+                }
+                _ => SessionEvent::Raw {
+                    value: value.clone(),
+                },
+            }
+        }
+        "turn.completed" => SessionEvent::Done {
+            text: None,
+            usage: value.get("usage").cloned(),
+        },
+        _ => SessionEvent::Raw {
+            value: value.clone(),
+        },
+    }
+}
+
+fn collect(event: &SessionEvent, into: &mut SessionResult) {
+    match event {
+        SessionEvent::SessionStarted { session_id } => {
+            into.session_id = Some(session_id.clone());
+        }
+        SessionEvent::AssistantText { text } => match &mut into.final_text {
+            Some(existing) => existing.push_str(text),
+            None => into.final_text = Some(text.clone()),
+        },
+        _ => {}
+    }
+}
+
+/// Pull a top-level `key = "value"` out of a TOML file. We only need the very
+/// first occurrence and intentionally do not handle tables or arrays. Avoids
+/// adding a TOML parser dependency for one read.
+fn extract_top_level_string(contents: &str, key: &str) -> Option<String> {
+    for raw in contents.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if line.starts_with('[') {
+            // We stop at the first table header — keys after that are nested.
+            return None;
+        }
+        if let Some((k, v)) = line.split_once('=') {
+            if k.trim() == key {
+                let v = v.trim().trim_matches('"');
+                return Some(v.to_string());
+            }
+        }
+    }
+    None
+}

--- a/crates/agents/src/detect.rs
+++ b/crates/agents/src/detect.rs
@@ -1,0 +1,71 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::types::{AgentInfo, AgentKind, Error, Result};
+
+/// Run `binary <args...>` capturing stdout. Returns the trimmed stdout on
+/// success. Stderr is folded into the error so callers can debug failed
+/// invocations.
+pub(crate) fn run_capture(binary: &str, args: &[&str]) -> Result<String> {
+    let output = Command::new(binary).args(args).output().map_err(|source| {
+        if source.kind() == std::io::ErrorKind::NotFound {
+            Error::Spawn {
+                cmd: binary.to_string(),
+                source,
+            }
+        } else {
+            Error::Spawn {
+                cmd: binary.to_string(),
+                source,
+            }
+        }
+    })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        return Err(Error::NonZeroExit {
+            cmd: format!("{binary} {}", args.join(" ")),
+            status: output.status.code().unwrap_or(-1),
+            stderr,
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Locate `binary` on PATH. Returns `None` if it can't be found.
+pub(crate) fn locate(binary: &str) -> Option<PathBuf> {
+    which::which(binary).ok()
+}
+
+/// Quick helper for adapters: detect a binary, run a `--version`-like command,
+/// and produce an [`AgentInfo`]. The caller hands us the args used to print
+/// the version string and a closure that extracts the version from stdout.
+pub(crate) fn detect_with(
+    kind: AgentKind,
+    binary: &str,
+    version_args: &[&str],
+    parse_version: impl FnOnce(&str) -> String,
+) -> Result<Option<AgentInfo>> {
+    let Some(executable) = locate(binary) else {
+        return Ok(None);
+    };
+    let stdout = run_capture(binary, version_args)?;
+    Ok(Some(AgentInfo {
+        kind,
+        executable,
+        version: parse_version(&stdout),
+    }))
+}
+
+/// Detect every known agent in one shot, dropping the ones that aren't
+/// installed.
+pub fn detect_all() -> Vec<AgentInfo> {
+    let mut out = Vec::new();
+    for adapter in crate::all() {
+        match adapter.detect() {
+            Ok(Some(info)) => out.push(info),
+            Ok(None) => {}
+            Err(err) => log::warn!("detect {} failed: {err}", adapter.kind()),
+        }
+    }
+    out
+}

--- a/crates/agents/src/lib.rs
+++ b/crates/agents/src/lib.rs
@@ -1,0 +1,31 @@
+//! Adapters for CLI coding agents (claude, codex, opencode).
+//!
+//! Each agent is a separate binary on `PATH`. We do not link any of them in
+//! process; we drive them as subprocesses, parse their JSON event streams, and
+//! surface a uniform [`AgentCLI`] trait so the rest of `gesttalt` can stay
+//! agnostic to which agent the user picked.
+
+mod claude;
+mod codex;
+mod detect;
+mod opencode;
+mod types;
+
+pub use claude::Claude;
+pub use codex::Codex;
+pub use detect::detect_all;
+pub use opencode::OpenCode;
+pub use types::{
+    AgentCLI, AgentInfo, AgentKind, Error, Model, ReasoningEffort, Result, SessionEvent,
+    SessionRequest, SessionResult,
+};
+
+/// Iterate every agent adapter the crate knows about. Order is stable so
+/// callers can rely on it for display.
+pub fn all() -> Vec<Box<dyn AgentCLI>> {
+    vec![
+        Box::new(OpenCode::new()),
+        Box::new(Codex::new()),
+        Box::new(Claude::new()),
+    ]
+}

--- a/crates/agents/src/opencode.rs
+++ b/crates/agents/src/opencode.rs
@@ -1,0 +1,209 @@
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
+
+use crate::detect::{detect_with, run_capture};
+use crate::types::{
+    AgentCLI, AgentInfo, AgentKind, Error, Model, ReasoningEffort, Result, SessionEvent,
+    SessionRequest, SessionResult,
+};
+
+/// Adapter for the `opencode` CLI (https://opencode.ai).
+///
+/// Driving model: `opencode run --format json -m provider/model --variant <effort> "prompt"`.
+/// `--format json` makes opencode emit one JSON event per line on stdout, with
+/// shapes like `{"type":"text","part":{"text":...}}` and a final
+/// `{"type":"step_finish","part":{"tokens":...,"cost":...}}`.
+pub struct OpenCode;
+
+impl OpenCode {
+    pub fn new() -> Self {
+        Self
+    }
+
+    const BIN: &'static str = "opencode";
+}
+
+impl Default for OpenCode {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AgentCLI for OpenCode {
+    fn kind(&self) -> AgentKind {
+        AgentKind::OpenCode
+    }
+
+    fn detect(&self) -> Result<Option<AgentInfo>> {
+        detect_with(AgentKind::OpenCode, Self::BIN, &["--version"], |s| {
+            // `opencode --version` prints just the version, e.g. "1.3.15".
+            s.trim().to_string()
+        })
+    }
+
+    fn list_models(&self) -> Result<Vec<Model>> {
+        let stdout = run_capture(Self::BIN, &["models"])?;
+        let mut out = Vec::new();
+        for line in stdout.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            // opencode prints `provider/model` per line.
+            let (provider, _model) = line.split_once('/').unwrap_or(("opencode", line));
+            out.push(Model {
+                id: line.to_string(),
+                alias: None,
+                provider: provider.to_string(),
+                supports_reasoning: true,
+            });
+        }
+        if out.is_empty() {
+            return Err(Error::Parse {
+                cmd: "opencode models".into(),
+                detail: "no models returned".into(),
+            });
+        }
+        Ok(out)
+    }
+
+    fn reasoning_efforts(&self) -> Vec<ReasoningEffort> {
+        // From `opencode run --help`: --variant accepts provider-specific
+        // reasoning effort, "e.g. high, max, minimal". We expose the three
+        // they document.
+        vec![
+            ReasoningEffort::Minimal,
+            ReasoningEffort::High,
+            ReasoningEffort::Max,
+        ]
+    }
+
+    fn run_session(
+        &self,
+        req: &SessionRequest,
+        on_event: &mut dyn FnMut(&SessionEvent),
+    ) -> Result<SessionResult> {
+        let mut cmd = Command::new(Self::BIN);
+        cmd.arg("run").arg("--format").arg("json");
+        if let Some(model) = &req.model {
+            cmd.arg("-m").arg(model);
+        }
+        if let Some(effort) = req.effort {
+            cmd.arg("--variant").arg(effort.as_str());
+        }
+        if let Some(cwd) = &req.cwd {
+            cmd.arg("--dir").arg(cwd);
+        }
+        // The prompt is positional: `opencode run [message..]`. Pass via -- to
+        // be safe with leading dashes in the user prompt.
+        cmd.arg("--").arg(&req.prompt);
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(|source| Error::Spawn {
+            cmd: format!("{} run", Self::BIN),
+            source,
+        })?;
+        let stdout = child.stdout.take().expect("stdout was piped");
+        let reader = BufReader::new(stdout);
+
+        let mut result = SessionResult::default();
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let value: Value = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            let event = parse_event(&value);
+            collect(&event, &mut result);
+            on_event(&event);
+            result.events.push(event);
+        }
+
+        let status = child.wait()?;
+        if !status.success() {
+            let stderr = child
+                .stderr
+                .take()
+                .map(|mut s| {
+                    let mut buf = String::new();
+                    let _ = std::io::Read::read_to_string(&mut s, &mut buf);
+                    buf
+                })
+                .unwrap_or_default();
+            return Err(Error::NonZeroExit {
+                cmd: format!("{} run", Self::BIN),
+                status: status.code().unwrap_or(-1),
+                stderr,
+            });
+        }
+        Ok(result)
+    }
+}
+
+fn parse_event(value: &Value) -> SessionEvent {
+    let ty = value.get("type").and_then(Value::as_str).unwrap_or("");
+    let part = value.get("part");
+    match ty {
+        "step_start" => {
+            let session_id = value
+                .get("sessionID")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            SessionEvent::SessionStarted { session_id }
+        }
+        "text" => {
+            let text = part
+                .and_then(|p| p.get("text"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            SessionEvent::AssistantText { text }
+        }
+        "reasoning" => {
+            let text = part
+                .and_then(|p| p.get("text"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            SessionEvent::Reasoning { text }
+        }
+        "tool" | "tool_call" | "tool_use" => {
+            let name = part
+                .and_then(|p| p.get("name"))
+                .and_then(Value::as_str)
+                .unwrap_or("tool")
+                .to_string();
+            let input = part
+                .and_then(|p| p.get("input"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            SessionEvent::ToolUse { name, input }
+        }
+        "step_finish" => {
+            let usage = part.and_then(|p| p.get("tokens")).cloned();
+            SessionEvent::Done { text: None, usage }
+        }
+        _ => SessionEvent::Raw {
+            value: value.clone(),
+        },
+    }
+}
+
+fn collect(event: &SessionEvent, into: &mut SessionResult) {
+    match event {
+        SessionEvent::SessionStarted { session_id } => {
+            into.session_id = Some(session_id.clone());
+        }
+        SessionEvent::AssistantText { text } => match &mut into.final_text {
+            Some(existing) => existing.push_str(text),
+            None => into.final_text = Some(text.clone()),
+        },
+        _ => {}
+    }
+}

--- a/crates/agents/src/types.rs
+++ b/crates/agents/src/types.rs
@@ -1,0 +1,195 @@
+use std::fmt;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("agent `{0}` is not installed on PATH")]
+    NotInstalled(&'static str),
+    #[error("failed to spawn `{cmd}`: {source}")]
+    Spawn {
+        cmd: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("`{cmd}` exited with status {status}: {stderr}")]
+    NonZeroExit {
+        cmd: String,
+        status: i32,
+        stderr: String,
+    },
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("could not parse output of `{cmd}`: {detail}")]
+    Parse { cmd: String, detail: String },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// The set of CLI agents we know how to drive. New agents append to this enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum AgentKind {
+    OpenCode,
+    Codex,
+    Claude,
+}
+
+impl AgentKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AgentKind::OpenCode => "opencode",
+            AgentKind::Codex => "codex",
+            AgentKind::Claude => "claude",
+        }
+    }
+}
+
+impl fmt::Display for AgentKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentInfo {
+    pub kind: AgentKind,
+    pub executable: PathBuf,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Model {
+    /// The identifier passed to `--model`.
+    pub id: String,
+    /// Optional short label (e.g. `sonnet`, `opus`) the CLI also accepts.
+    pub alias: Option<String>,
+    /// Provider portion when the agent groups models by provider, otherwise
+    /// the agent's own name.
+    pub provider: String,
+    /// True if the model accepts a reasoning-effort knob.
+    pub supports_reasoning: bool,
+}
+
+/// Reasoning levels the various CLIs support. Each adapter returns the subset
+/// it actually accepts; we deliberately use a wider enum here because the CLIs
+/// don't agree on the same set (claude has `max`, codex has `none`, etc.) and
+/// it's useful to display the full picture in the UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ReasoningEffort {
+    None,
+    Minimal,
+    Low,
+    Medium,
+    High,
+    XHigh,
+    Max,
+}
+
+impl ReasoningEffort {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReasoningEffort::None => "none",
+            ReasoningEffort::Minimal => "minimal",
+            ReasoningEffort::Low => "low",
+            ReasoningEffort::Medium => "medium",
+            ReasoningEffort::High => "high",
+            ReasoningEffort::XHigh => "xhigh",
+            ReasoningEffort::Max => "max",
+        }
+    }
+}
+
+impl fmt::Display for ReasoningEffort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionRequest {
+    pub prompt: String,
+    pub model: Option<String>,
+    pub effort: Option<ReasoningEffort>,
+    pub cwd: Option<PathBuf>,
+}
+
+impl SessionRequest {
+    pub fn new(prompt: impl Into<String>) -> Self {
+        Self {
+            prompt: prompt.into(),
+            model: None,
+            effort: None,
+            cwd: None,
+        }
+    }
+    pub fn model(mut self, m: impl Into<String>) -> Self {
+        self.model = Some(m.into());
+        self
+    }
+    pub fn effort(mut self, e: ReasoningEffort) -> Self {
+        self.effort = Some(e);
+        self
+    }
+    pub fn cwd(mut self, p: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(p.into());
+        self
+    }
+}
+
+/// Normalised event stream every adapter emits while a session is running. We
+/// pick a small common vocabulary; the original payload is preserved in
+/// [`SessionEvent::Raw::value`] for callers that want full fidelity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SessionEvent {
+    /// The session has been assigned an id by the agent.
+    SessionStarted { session_id: String },
+    /// The model produced visible text (assistant turn output).
+    AssistantText { text: String },
+    /// The model produced a chunk of reasoning ("thinking"). Some agents only
+    /// emit this when explicitly asked for it.
+    Reasoning { text: String },
+    /// The agent invoked a tool / executed a shell command.
+    ToolUse { name: String, input: serde_json::Value },
+    /// The session finished. `text` is the final assistant message if the
+    /// adapter could pull one out.
+    Done {
+        text: Option<String>,
+        usage: Option<serde_json::Value>,
+    },
+    /// Anything we recognised but didn't normalise.
+    Raw { value: serde_json::Value },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SessionResult {
+    pub session_id: Option<String>,
+    pub final_text: Option<String>,
+    pub events: Vec<SessionEvent>,
+}
+
+pub trait AgentCLI: Send + Sync {
+    fn kind(&self) -> AgentKind;
+
+    /// Locate the binary on PATH and read its version. Returns `None` if the
+    /// binary is not installed.
+    fn detect(&self) -> Result<Option<AgentInfo>>;
+
+    /// Models exposed by this CLI. May hit the network or read local config.
+    fn list_models(&self) -> Result<Vec<Model>>;
+
+    /// Reasoning levels this CLI accepts. The set is intrinsic to the CLI,
+    /// not per-model — the same enum applies to whatever `--model` the caller
+    /// picks, even if the underlying provider silently ignores it.
+    fn reasoning_efforts(&self) -> Vec<ReasoningEffort>;
+
+    /// Run a one-shot session. Events are streamed via `on_event`; the result
+    /// also collects them so callers that don't want streaming can ignore the
+    /// callback. Pass `|_| {}` if you don't care.
+    fn run_session(
+        &self,
+        req: &SessionRequest,
+        on_event: &mut dyn FnMut(&SessionEvent),
+    ) -> Result<SessionResult>;
+}


### PR DESCRIPTION
## Summary
- New `agents` workspace crate that detects, lists models + reasoning levels for, and runs sessions against `opencode`, `codex`, and `claude` CLIs.
- Common `AgentCLI` trait with normalised `SessionEvent` stream so the rest of `gesttalt` can stay agent-agnostic; raw JSON from each CLI is preserved in `SessionEvent::Raw` for high-fidelity callers.
- `agents-probe` binary that exercises every adapter end to end (`cargo run -p agents --bin agents-probe`).
- Adds `AGENTS.md` describing the project (Rust agentic coding env on GPUI with first-party fabrik integration); `CLAUDE.md` is a symlink to it.

## CLI quirks captured in the adapters
- **opencode** `1.3.15`: `opencode models` lists `provider/model`; reasoning via `--variant minimal|high|max`; `--format json` JSONL events.
- **codex** `0.128.0`: no model-list command (config-driven); curated set + reads default model from `~/.codex/config.toml`; reasoning levels `none/minimal/low/medium/high/xhigh` via `-c model_reasoning_effort=…`.
- **claude** `2.1.131`: model aliases (`sonnet/opus/haiku`) + full names; `--effort low|medium|high|xhigh|max`; `--output-format stream-json --include-partial-messages` for per-token deltas.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo run -p agents --bin agents-probe` detects all three locally installed CLIs, lists their models, prints reasoning levels, and streams a probe session for each
- [ ] Run probe again on a fresh checkout to confirm reproducibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)