### PR TITLE
feat: command palette, settings view, and Cmd+Q quit

### DIFF
--- a/.github/workflows/guestout.yaml
+++ b/.github/workflows/guestout.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: short
@@ -23,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           experimental: true
       - run: rustup component add rustfmt --toolchain $RUST_TOOLCHAIN
@@ -46,11 +49,11 @@ jobs:
             libxkbcommon-dev libxkbcommon-x11-dev \
             libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libvulkan-dev mesa-vulkan-drivers
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           experimental: true
       - run: rustup component add clippy --toolchain $RUST_TOOLCHAIN
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: linux
       - run: cargo clippy --workspace --all-targets --locked
@@ -83,10 +86,10 @@ jobs:
             libxkbcommon-dev libxkbcommon-x11-dev \
             libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libvulkan-dev mesa-vulkan-drivers
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           experimental: true
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ${{ matrix.name }}
       - run: cargo build --workspace --locked
@@ -119,10 +122,10 @@ jobs:
             libxkbcommon-dev libxkbcommon-x11-dev \
             libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libvulkan-dev mesa-vulkan-drivers
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           experimental: true
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: ${{ matrix.name }}
       - run: cargo test --workspace --locked

--- a/.github/workflows/guestout.yaml
+++ b/.github/workflows/guestout.yaml
@@ -52,13 +52,13 @@ jobs:
       - run: rustup component add clippy --toolchain $RUST_TOOLCHAIN
       - uses: Swatinem/rust-cache@v2
         with:
-          # Share the cache across this job and `build-test` since they
+          # Share the cache across this job and `build-linux` since they
           # compile the same code.
           shared-key: linux
       - run: cargo clippy --workspace --all-targets --locked
 
-  build-test:
-    name: build & test
+  build-linux:
+    name: build & test (linux)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,3 +82,16 @@ jobs:
           shared-key: linux
       - run: cargo build --workspace --all-targets --locked
       - run: cargo test --workspace --locked
+
+  build-windows:
+    name: build (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+        with:
+          experimental: true
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows
+      - run: cargo build --workspace --locked

--- a/.github/workflows/guestout.yaml
+++ b/.github/workflows/guestout.yaml
@@ -52,17 +52,26 @@ jobs:
       - run: rustup component add clippy --toolchain $RUST_TOOLCHAIN
       - uses: Swatinem/rust-cache@v2
         with:
-          # Share the cache across this job and `build-linux` since they
-          # compile the same code.
           shared-key: linux
       - run: cargo clippy --workspace --all-targets --locked
 
-  build-linux:
-    name: build & test (linux)
-    runs-on: ubuntu-latest
+  build:
+    name: build (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux
+            os: ubuntu-latest
+          - name: windows
+            os: windows-latest
+          - name: macos
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Install GPUI Linux build dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -79,19 +88,41 @@ jobs:
           experimental: true
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: linux
-      - run: cargo build --workspace --all-targets --locked
-      - run: cargo test --workspace --locked
+          shared-key: ${{ matrix.name }}
+      - run: cargo build --workspace --locked
 
-  build-windows:
-    name: build (windows)
-    runs-on: windows-latest
+  test:
+    name: test (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux
+            os: ubuntu-latest
+          - name: windows
+            os: windows-latest
+          - name: macos
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install GPUI Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config cmake clang \
+            libasound2-dev \
+            libfontconfig1-dev libfreetype6-dev \
+            libssl-dev libzstd-dev \
+            libwayland-dev wayland-protocols \
+            libxkbcommon-dev libxkbcommon-x11-dev \
+            libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
+            libvulkan-dev mesa-vulkan-drivers
       - uses: jdx/mise-action@v2
         with:
           experimental: true
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: windows
-      - run: cargo build --workspace --locked
+          shared-key: ${{ matrix.name }}
+      - run: cargo test --workspace --locked

--- a/crates/gesttalt/src/command_palette.rs
+++ b/crates/gesttalt/src/command_palette.rs
@@ -110,14 +110,16 @@ impl CommandPalette {
         };
         let action = command.action.as_ref();
         workspace.update(cx, |workspace, cx| {
-            workspace.dismiss_command_palette(cx);
+            workspace.dismiss_command_palette(window, cx);
             (action)(workspace, window, cx);
         });
     }
 
-    fn dismiss(&mut self, _: &Dismiss, _: &mut Window, cx: &mut Context<Self>) {
+    fn dismiss(&mut self, _: &Dismiss, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(workspace) = self.workspace.upgrade() {
-            workspace.update(cx, |workspace, cx| workspace.dismiss_command_palette(cx));
+            workspace.update(cx, |workspace, cx| {
+                workspace.dismiss_command_palette(window, cx)
+            });
         }
     }
 

--- a/crates/gesttalt/src/command_palette.rs
+++ b/crates/gesttalt/src/command_palette.rs
@@ -1,0 +1,280 @@
+use gpui::{
+    App, Context, FocusHandle, Focusable, IntoElement, KeyDownEvent, MouseButton, ParentElement,
+    Render, SharedString, Styled, WeakEntity, Window, actions, div, prelude::*, px, rems,
+};
+
+use crate::theme;
+use crate::workspace::Workspace;
+
+actions!(
+    command_palette,
+    [
+        /// Toggles the command palette modal.
+        Toggle,
+        /// Selects the next command in the list.
+        SelectNext,
+        /// Selects the previous command in the list.
+        SelectPrev,
+        /// Invokes the highlighted command.
+        Confirm,
+        /// Closes the command palette without invoking anything.
+        Dismiss,
+    ]
+);
+
+pub type CommandHandler = Box<dyn Fn(&mut Workspace, &mut Window, &mut Context<Workspace>)>;
+
+pub struct Command {
+    pub name: SharedString,
+    pub keybinding: Option<SharedString>,
+    pub action: CommandHandler,
+}
+
+pub struct CommandPalette {
+    workspace: WeakEntity<Workspace>,
+    focus_handle: FocusHandle,
+    query: String,
+    selected: usize,
+    commands: Vec<Command>,
+    visible_indices: Vec<usize>,
+}
+
+impl CommandPalette {
+    pub fn new(
+        workspace: WeakEntity<Workspace>,
+        commands: Vec<Command>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let visible_indices = (0..commands.len()).collect();
+        Self {
+            workspace,
+            focus_handle: cx.focus_handle(),
+            query: String::new(),
+            selected: 0,
+            commands,
+            visible_indices,
+        }
+    }
+
+    pub fn focus_handle(&self) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+
+    fn refresh_matches(&mut self) {
+        let query = self.query.trim().to_lowercase();
+        self.visible_indices = self
+            .commands
+            .iter()
+            .enumerate()
+            .filter(|(_, cmd)| {
+                if query.is_empty() {
+                    true
+                } else {
+                    cmd.name.to_lowercase().contains(&query)
+                }
+            })
+            .map(|(i, _)| i)
+            .collect();
+        self.selected = 0;
+    }
+
+    fn select_next(&mut self, _: &SelectNext, _: &mut Window, cx: &mut Context<Self>) {
+        if self.visible_indices.is_empty() {
+            return;
+        }
+        self.selected = (self.selected + 1) % self.visible_indices.len();
+        cx.notify();
+    }
+
+    fn select_prev(&mut self, _: &SelectPrev, _: &mut Window, cx: &mut Context<Self>) {
+        if self.visible_indices.is_empty() {
+            return;
+        }
+        self.selected = if self.selected == 0 {
+            self.visible_indices.len() - 1
+        } else {
+            self.selected - 1
+        };
+        cx.notify();
+    }
+
+    fn confirm(&mut self, _: &Confirm, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(&command_index) = self.visible_indices.get(self.selected) else {
+            return;
+        };
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+        let Some(command) = self.commands.get(command_index) else {
+            return;
+        };
+        let action = command.action.as_ref();
+        workspace.update(cx, |workspace, cx| {
+            workspace.dismiss_command_palette(cx);
+            (action)(workspace, window, cx);
+        });
+    }
+
+    fn dismiss(&mut self, _: &Dismiss, _: &mut Window, cx: &mut Context<Self>) {
+        if let Some(workspace) = self.workspace.upgrade() {
+            workspace.update(cx, |workspace, cx| workspace.dismiss_command_palette(cx));
+        }
+    }
+
+    fn handle_key_down(&mut self, event: &KeyDownEvent, _: &mut Window, cx: &mut Context<Self>) {
+        let modifiers = event.keystroke.modifiers;
+        if modifiers.control || modifiers.alt || modifiers.platform {
+            return;
+        }
+        match event.keystroke.key.as_str() {
+            "backspace" => {
+                if self.query.pop().is_some() {
+                    self.refresh_matches();
+                    cx.notify();
+                }
+                return;
+            }
+            "up" | "down" | "enter" | "escape" | "tab" | "left" | "right" | "home" | "end" => {
+                return;
+            }
+            _ => {}
+        }
+        let Some(typed) = event.keystroke.key_char.as_ref() else {
+            return;
+        };
+        let mut changed = false;
+        for ch in typed.chars() {
+            if !ch.is_control() {
+                self.query.push(ch);
+                changed = true;
+            }
+        }
+        if changed {
+            self.refresh_matches();
+            cx.notify();
+        }
+    }
+}
+
+impl Focusable for CommandPalette {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for CommandPalette {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let placeholder = self.query.is_empty();
+        let query_text: SharedString = if placeholder {
+            "Type a command…".into()
+        } else {
+            self.query.clone().into()
+        };
+        let query_color = if placeholder {
+            theme::text_muted()
+        } else {
+            theme::text()
+        };
+
+        let visible: Vec<(SharedString, Option<SharedString>, bool)> = self
+            .visible_indices
+            .iter()
+            .enumerate()
+            .map(|(row_idx, &cmd_idx)| {
+                let cmd = &self.commands[cmd_idx];
+                (
+                    cmd.name.clone(),
+                    cmd.keybinding.clone(),
+                    row_idx == self.selected,
+                )
+            })
+            .collect();
+
+        let empty_message = visible.is_empty().then(|| {
+            div()
+                .px_3()
+                .py_4()
+                .text_color(theme::text_muted())
+                .text_sm()
+                .child("No matching commands")
+        });
+
+        div()
+            .key_context("CommandPalette")
+            .track_focus(&self.focus_handle)
+            .on_action(cx.listener(Self::select_next))
+            .on_action(cx.listener(Self::select_prev))
+            .on_action(cx.listener(Self::confirm))
+            .on_action(cx.listener(Self::dismiss))
+            .on_key_down(cx.listener(Self::handle_key_down))
+            .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+            .w(rems(34.))
+            .max_h(rems(28.))
+            .bg(theme::elevated())
+            .border_1()
+            .border_color(theme::border())
+            .rounded_lg()
+            .shadow_lg()
+            .flex()
+            .flex_col()
+            .overflow_hidden()
+            .child(
+                div()
+                    .px_3()
+                    .py_2p5()
+                    .border_b_1()
+                    .border_color(theme::border())
+                    .text_color(query_color)
+                    .text_sm()
+                    .child(query_text),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .min_h(px(0.))
+                    .overflow_hidden()
+                    .py_1()
+                    .when_some(empty_message, |this, msg| this.child(msg))
+                    .children(visible.into_iter().enumerate().map(
+                        |(row_idx, (name, keybinding, selected))| {
+                            let row = div()
+                                .id(("command-palette-row", row_idx))
+                                .px_3()
+                                .py_1p5()
+                                .flex()
+                                .flex_row()
+                                .items_center()
+                                .justify_between()
+                                .text_sm()
+                                .cursor_pointer()
+                                .child(div().child(name));
+                            let row = if selected {
+                                row.bg(theme::selection()).text_color(theme::text())
+                            } else {
+                                row.text_color(theme::text_muted())
+                                    .hover(|s| s.bg(theme::hover()).text_color(theme::text()))
+                            };
+                            let row = row.when_some(keybinding, |this, kb| {
+                                this.child(
+                                    div()
+                                        .px_1p5()
+                                        .py_0p5()
+                                        .rounded_sm()
+                                        .bg(theme::panel())
+                                        .text_color(theme::text_muted())
+                                        .text_xs()
+                                        .child(kb),
+                                )
+                            });
+                            row.on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(move |this, _, window, cx| {
+                                    this.selected = row_idx;
+                                    this.confirm(&Confirm, window, cx);
+                                }),
+                            )
+                        },
+                    )),
+            )
+    }
+}

--- a/crates/gesttalt/src/dev_tools.rs
+++ b/crates/gesttalt/src/dev_tools.rs
@@ -1,0 +1,28 @@
+use gpui::SharedString;
+
+#[derive(Clone)]
+pub struct DevTool {
+    pub name: SharedString,
+    pub description: SharedString,
+}
+
+pub fn default_dev_tools() -> Vec<DevTool> {
+    vec![
+        DevTool {
+            name: "Workspace Bounds".into(),
+            description: "Inspect the live bounds of the workspace and dock sizes.".into(),
+        },
+        DevTool {
+            name: "Theme Inspector".into(),
+            description: "Browse the active theme's color tokens.".into(),
+        },
+        DevTool {
+            name: "Agent Probe".into(),
+            description: "Send a tiny prompt to each detected coding-agent CLI.".into(),
+        },
+        DevTool {
+            name: "Keymap Inspector".into(),
+            description: "View the registered actions and their key bindings.".into(),
+        },
+    ]
+}

--- a/crates/gesttalt/src/main.rs
+++ b/crates/gesttalt/src/main.rs
@@ -1,10 +1,13 @@
 use anyhow::Result;
 use gpui::{
-    App, AppContext, Application, Bounds, Size, TitlebarOptions, WindowBounds, WindowOptions,
-    point, px, size,
+    App, AppContext, Application, Bounds, Focusable, KeyBinding, Menu, MenuItem, Size,
+    TitlebarOptions, WindowBounds, WindowOptions, actions, point, px, size,
 };
 
+mod command_palette;
+mod dev_tools;
 mod dock;
+mod settings;
 mod status_bar;
 mod theme;
 mod title_bar;
@@ -12,28 +15,69 @@ mod workspace;
 
 use workspace::Workspace;
 
+actions!(
+    gesttalt,
+    [
+        /// Quits the application.
+        Quit,
+    ]
+);
+
+#[cfg(target_os = "macos")]
+const COMMAND_PALETTE_KEY: &str = "cmd-k";
+#[cfg(not(target_os = "macos"))]
+const COMMAND_PALETTE_KEY: &str = "ctrl-k";
+
+#[cfg(target_os = "macos")]
+const QUIT_KEY: &str = "cmd-q";
+#[cfg(not(target_os = "macos"))]
+const QUIT_KEY: &str = "ctrl-q";
+
 fn main() -> Result<()> {
     env_logger::init();
 
     Application::new().run(|cx: &mut App| {
+        cx.on_action(|_: &Quit, cx| cx.quit());
+
+        cx.bind_keys([
+            KeyBinding::new(QUIT_KEY, Quit, None),
+            KeyBinding::new(COMMAND_PALETTE_KEY, command_palette::Toggle, None),
+            KeyBinding::new("up", command_palette::SelectPrev, Some("CommandPalette")),
+            KeyBinding::new("down", command_palette::SelectNext, Some("CommandPalette")),
+            KeyBinding::new("enter", command_palette::Confirm, Some("CommandPalette")),
+            KeyBinding::new("escape", command_palette::Dismiss, Some("CommandPalette")),
+        ]);
+
+        cx.set_menus(vec![Menu {
+            name: "Gesttalt".into(),
+            items: vec![MenuItem::action("Quit Gesttalt", Quit)],
+        }]);
+
         let bounds = Bounds::centered(None, size(px(1100.), px(720.)), cx);
-        cx.open_window(
-            WindowOptions {
-                window_bounds: Some(WindowBounds::Windowed(bounds)),
-                titlebar: Some(TitlebarOptions {
-                    title: None,
-                    appears_transparent: true,
-                    traffic_light_position: Some(point(px(9.0), px(9.0))),
-                }),
-                window_min_size: Some(Size {
-                    width: px(640.),
-                    height: px(400.),
-                }),
-                ..Default::default()
-            },
-            |_, cx| cx.new(Workspace::new),
-        )
-        .expect("failed to open window");
+        let window = cx
+            .open_window(
+                WindowOptions {
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
+                    titlebar: Some(TitlebarOptions {
+                        title: None,
+                        appears_transparent: true,
+                        traffic_light_position: Some(point(px(9.0), px(9.0))),
+                    }),
+                    window_min_size: Some(Size {
+                        width: px(640.),
+                        height: px(400.),
+                    }),
+                    ..Default::default()
+                },
+                |_, cx| cx.new(Workspace::new),
+            )
+            .expect("failed to open window");
+
+        window
+            .update(cx, |workspace, window, cx| {
+                window.focus(&workspace.focus_handle(cx));
+            })
+            .ok();
 
         cx.activate(true);
     });

--- a/crates/gesttalt/src/settings.rs
+++ b/crates/gesttalt/src/settings.rs
@@ -1,0 +1,299 @@
+use gpui::{
+    AnyElement, Context, IntoElement, MouseButton, ParentElement, Render, SharedString, Styled,
+    Window, div, prelude::*, px,
+};
+
+use crate::dev_tools::{DevTool, default_dev_tools};
+use crate::theme;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SettingsSection {
+    General,
+    Appearance,
+    Agents,
+    DevTools,
+}
+
+impl SettingsSection {
+    fn title(self) -> &'static str {
+        match self {
+            SettingsSection::General => "General",
+            SettingsSection::Appearance => "Appearance",
+            SettingsSection::Agents => "Agents",
+            SettingsSection::DevTools => "Dev Tools",
+        }
+    }
+
+    fn description(self) -> &'static str {
+        match self {
+            SettingsSection::General => "Workspace defaults, project root, and startup behavior.",
+            SettingsSection::Appearance => "Theme, fonts, and chrome density.",
+            SettingsSection::Agents => "CLI coding-agent adapters and their default models.",
+            SettingsSection::DevTools => {
+                "Internal tools you can attach to the workspace to debug Gesttalt itself."
+            }
+        }
+    }
+
+    fn all() -> &'static [SettingsSection] {
+        &[
+            SettingsSection::General,
+            SettingsSection::Appearance,
+            SettingsSection::Agents,
+            SettingsSection::DevTools,
+        ]
+    }
+}
+
+pub struct SettingsView {
+    selected: SettingsSection,
+    dev_tools: Vec<DevTool>,
+    active_dev_tool: Option<usize>,
+}
+
+impl SettingsView {
+    pub fn new(_cx: &mut Context<Self>) -> Self {
+        Self {
+            selected: SettingsSection::General,
+            dev_tools: default_dev_tools(),
+            active_dev_tool: None,
+        }
+    }
+
+    fn select(&mut self, section: SettingsSection, cx: &mut Context<Self>) {
+        if self.selected != section {
+            self.selected = section;
+            self.active_dev_tool = None;
+            cx.notify();
+        }
+    }
+
+    fn render_nav(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let mut nav = div()
+            .w(px(220.))
+            .h_full()
+            .flex_none()
+            .flex()
+            .flex_col()
+            .p_3()
+            .gap_1()
+            .border_r_1()
+            .border_color(theme::border())
+            .bg(theme::panel())
+            .child(
+                div()
+                    .pb_2()
+                    .text_color(theme::text_muted())
+                    .text_xs()
+                    .child("SETTINGS"),
+            );
+
+        for (index, &section) in SettingsSection::all().iter().enumerate() {
+            let selected = section == self.selected;
+            let label = section.title();
+            let row = div()
+                .id(("settings-nav", index))
+                .px_2()
+                .py_1p5()
+                .rounded_md()
+                .text_sm()
+                .cursor_pointer()
+                .child(label);
+            let row = if selected {
+                row.bg(theme::selection()).text_color(theme::text())
+            } else {
+                row.text_color(theme::text_muted())
+                    .hover(|s| s.bg(theme::hover()).text_color(theme::text()))
+            };
+            nav = nav.child(row.on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, _, cx| {
+                    this.select(section, cx);
+                }),
+            ));
+        }
+
+        nav
+    }
+
+    fn render_page(&self, cx: &mut Context<Self>) -> AnyElement {
+        match self.selected {
+            SettingsSection::DevTools => self.render_dev_tools(cx).into_any_element(),
+            section => self.render_placeholder_page(section).into_any_element(),
+        }
+    }
+
+    fn render_placeholder_page(&self, section: SettingsSection) -> impl IntoElement {
+        let title: SharedString = section.title().into();
+        let description: SharedString = section.description().into();
+        div()
+            .flex_1()
+            .h_full()
+            .flex()
+            .flex_col()
+            .gap_4()
+            .p_8()
+            .child(
+                div()
+                    .text_color(theme::text())
+                    .text_xl()
+                    .child(title.clone()),
+            )
+            .child(
+                div()
+                    .text_color(theme::text_muted())
+                    .text_sm()
+                    .child(description),
+            )
+            .child(
+                div()
+                    .mt_4()
+                    .p_4()
+                    .rounded_md()
+                    .border_1()
+                    .border_color(theme::border())
+                    .bg(theme::panel())
+                    .text_color(theme::text_muted())
+                    .text_sm()
+                    .child(format!("{} settings have not been implemented yet.", title)),
+            )
+    }
+
+    fn render_dev_tools(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let mut page = div()
+            .flex_1()
+            .h_full()
+            .flex()
+            .flex_col()
+            .p_8()
+            .gap_4()
+            .child(
+                div()
+                    .text_color(theme::text())
+                    .text_xl()
+                    .child(SettingsSection::DevTools.title()),
+            )
+            .child(
+                div()
+                    .text_color(theme::text_muted())
+                    .text_sm()
+                    .child(SettingsSection::DevTools.description()),
+            );
+
+        let mut list = div().mt_2().flex().flex_col().gap_2().child(
+            div()
+                .text_color(theme::text_muted())
+                .text_xs()
+                .child("AVAILABLE TOOLS"),
+        );
+
+        for (index, tool) in self.dev_tools.iter().enumerate() {
+            let active = self.active_dev_tool == Some(index);
+            let name = tool.name.clone();
+            let description = tool.description.clone();
+            let card = div()
+                .id(("dev-tool", index))
+                .p_3()
+                .rounded_md()
+                .border_1()
+                .border_color(theme::border())
+                .bg(theme::panel())
+                .cursor_pointer()
+                .flex()
+                .flex_col()
+                .gap_1()
+                .child(
+                    div()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .justify_between()
+                        .child(div().text_color(theme::text()).text_sm().child(name))
+                        .child({
+                            let badge = div().text_xs();
+                            let badge = if active {
+                                badge.text_color(theme::accent())
+                            } else {
+                                badge.text_color(theme::text_muted())
+                            };
+                            badge.child(if active { "Active" } else { "Attach" })
+                        }),
+                )
+                .child(
+                    div()
+                        .text_color(theme::text_muted())
+                        .text_xs()
+                        .child(description),
+                );
+
+            let card = if active {
+                card.border_color(theme::accent())
+            } else {
+                card.hover(|s| s.bg(theme::hover()))
+            };
+
+            list = list.child(card.on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _, _, cx| {
+                    this.active_dev_tool = if this.active_dev_tool == Some(index) {
+                        None
+                    } else {
+                        Some(index)
+                    };
+                    cx.notify();
+                }),
+            ));
+        }
+
+        page = page.child(list);
+
+        if let Some(index) = self.active_dev_tool
+            && let Some(tool) = self.dev_tools.get(index)
+        {
+            page = page.child(
+                div()
+                    .mt_4()
+                    .p_4()
+                    .rounded_md()
+                    .border_1()
+                    .border_color(theme::border())
+                    .bg(theme::elevated())
+                    .flex()
+                    .flex_col()
+                    .gap_2()
+                    .child(
+                        div()
+                            .text_color(theme::text())
+                            .text_sm()
+                            .child(format!("{} — Output", tool.name)),
+                    )
+                    .child(
+                        div()
+                            .text_color(theme::text_muted())
+                            .text_xs()
+                            .child("This tool has no implementation wired up yet. Drop a renderer in crates/gesttalt/src/dev_tools.rs to plug it in."),
+                    ),
+            );
+        }
+
+        page
+    }
+}
+
+impl Render for SettingsView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .flex()
+            .flex_row()
+            .bg(theme::background())
+            .child(self.render_nav(cx))
+            .child(
+                div()
+                    .flex_1()
+                    .h_full()
+                    .overflow_hidden()
+                    .child(self.render_page(cx)),
+            )
+    }
+}

--- a/crates/gesttalt/src/theme.rs
+++ b/crates/gesttalt/src/theme.rs
@@ -1,4 +1,4 @@
-use gpui::{Rgba, rgb};
+use gpui::{Hsla, Rgba, hsla, rgb};
 
 pub fn background() -> Rgba {
     rgb(0x1e1e2e)
@@ -26,4 +26,16 @@ pub fn text_muted() -> Rgba {
 
 pub fn accent() -> Rgba {
     rgb(0x89b4fa)
+}
+
+pub fn selection() -> Rgba {
+    rgb(0x45475a)
+}
+
+pub fn hover() -> Rgba {
+    rgb(0x313244)
+}
+
+pub fn modal_backdrop() -> Hsla {
+    hsla(0.0, 0.0, 0.0, 0.45)
 }

--- a/crates/gesttalt/src/workspace.rs
+++ b/crates/gesttalt/src/workspace.rs
@@ -197,9 +197,7 @@ impl Render for Workspace {
                     .pt(px(96.))
                     .on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(|this, _, window, cx| {
-                            this.dismiss_command_palette(window, cx)
-                        }),
+                        cx.listener(|this, _, window, cx| this.dismiss_command_palette(window, cx)),
                     )
                     .child(palette.clone()),
             )

--- a/crates/gesttalt/src/workspace.rs
+++ b/crates/gesttalt/src/workspace.rs
@@ -115,8 +115,7 @@ impl Workspace {
         cx: &mut Context<Self>,
     ) {
         if self.command_palette.is_some() {
-            self.dismiss_command_palette(cx);
-            window.focus(&self.focus_handle);
+            self.dismiss_command_palette(window, cx);
         } else {
             self.open_command_palette(window, cx);
         }
@@ -131,8 +130,9 @@ impl Workspace {
         cx.notify();
     }
 
-    pub fn dismiss_command_palette(&mut self, cx: &mut Context<Self>) {
+    pub fn dismiss_command_palette(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.command_palette.take().is_some() {
+            window.focus(&self.focus_handle);
             cx.notify();
         }
     }
@@ -197,7 +197,9 @@ impl Render for Workspace {
                     .pt(px(96.))
                     .on_mouse_down(
                         MouseButton::Left,
-                        cx.listener(|this, _, _, cx| this.dismiss_command_palette(cx)),
+                        cx.listener(|this, _, window, cx| {
+                            this.dismiss_command_palette(window, cx)
+                        }),
                     )
                     .child(palette.clone()),
             )

--- a/crates/gesttalt/src/workspace.rs
+++ b/crates/gesttalt/src/workspace.rs
@@ -1,9 +1,14 @@
 use gpui::{
-    Bounds, Context, DragMoveEvent, Entity, IntoElement, Pixels, Point, Render, Window, canvas,
-    div, prelude::*, px,
+    Bounds, Context, DragMoveEvent, Entity, FocusHandle, Focusable, IntoElement, MouseButton,
+    ParentElement, Pixels, Point, Render, Styled, Window, actions, canvas, deferred, div,
+    prelude::*, px,
 };
 
+use crate::command_palette::{
+    Command, CommandHandler, CommandPalette, Toggle as ToggleCommandPalette,
+};
 use crate::dock::{Dock, DockPosition, DraggedDock, RESIZE_HANDLE_SIZE};
+use crate::settings::SettingsView;
 use crate::status_bar::StatusBar;
 use crate::theme;
 use crate::title_bar::TitleBar;
@@ -13,6 +18,21 @@ const MAX_HORIZONTAL_DOCK_SIZE: Pixels = px(600.0);
 const MIN_BOTTOM_DOCK_SIZE: Pixels = px(80.0);
 const MAX_BOTTOM_DOCK_SIZE: Pixels = px(600.0);
 
+actions!(
+    workspace,
+    [
+        /// Opens the settings view in the workspace center.
+        OpenSettings,
+        /// Returns the workspace center to the default view.
+        CloseSettings,
+    ]
+);
+
+enum CenterView {
+    Default,
+    Settings(Entity<SettingsView>),
+}
+
 pub struct Workspace {
     title_bar: Entity<TitleBar>,
     left_dock: Entity<Dock>,
@@ -21,6 +41,9 @@ pub struct Workspace {
     status_bar: Entity<StatusBar>,
     main_bounds: Bounds<Pixels>,
     previous_drag_position: Option<Point<Pixels>>,
+    focus_handle: FocusHandle,
+    command_palette: Option<Entity<CommandPalette>>,
+    center: CenterView,
 }
 
 impl Workspace {
@@ -33,6 +56,9 @@ impl Workspace {
             status_bar: cx.new(|_| StatusBar::new()),
             main_bounds: Bounds::default(),
             previous_drag_position: None,
+            focus_handle: cx.focus_handle(),
+            command_palette: None,
+            center: CenterView::Default,
         }
     }
 
@@ -81,6 +107,68 @@ impl Workspace {
             }
         }
     }
+
+    fn toggle_command_palette(
+        &mut self,
+        _: &ToggleCommandPalette,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.command_palette.is_some() {
+            self.dismiss_command_palette(cx);
+            window.focus(&self.focus_handle);
+        } else {
+            self.open_command_palette(window, cx);
+        }
+    }
+
+    fn open_command_palette(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let workspace = cx.entity().downgrade();
+        let commands = default_commands();
+        let palette = cx.new(|cx| CommandPalette::new(workspace, commands, cx));
+        window.focus(&palette.read(cx).focus_handle());
+        self.command_palette = Some(palette);
+        cx.notify();
+    }
+
+    pub fn dismiss_command_palette(&mut self, cx: &mut Context<Self>) {
+        if self.command_palette.take().is_some() {
+            cx.notify();
+        }
+    }
+
+    fn open_settings(&mut self, _: &OpenSettings, _: &mut Window, cx: &mut Context<Self>) {
+        if matches!(self.center, CenterView::Settings(_)) {
+            return;
+        }
+        let view = cx.new(SettingsView::new);
+        self.center = CenterView::Settings(view);
+        cx.notify();
+    }
+
+    fn close_settings(&mut self, _: &CloseSettings, _: &mut Window, cx: &mut Context<Self>) {
+        if matches!(self.center, CenterView::Default) {
+            return;
+        }
+        self.center = CenterView::Default;
+        cx.notify();
+    }
+
+    fn render_default_center(&self) -> impl IntoElement {
+        div()
+            .flex_1()
+            .flex()
+            .items_center()
+            .justify_center()
+            .text_color(theme::text_muted())
+            .child("Center")
+    }
+}
+
+impl Focusable for Workspace {
+    fn focus_handle(&self, _: &gpui::App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
 }
 
 impl Render for Workspace {
@@ -97,42 +185,117 @@ impl Render for Workspace {
         .absolute()
         .size_full();
 
+        let palette_overlay = self.command_palette.as_ref().map(|palette| {
+            deferred(
+                div()
+                    .absolute()
+                    .inset_0()
+                    .bg(theme::modal_backdrop())
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .pt(px(96.))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, _, _, cx| this.dismiss_command_palette(cx)),
+                    )
+                    .child(palette.clone()),
+            )
+            .with_priority(2)
+        });
+
+        let body = match &self.center {
+            CenterView::Settings(view) => div()
+                .relative()
+                .flex_1()
+                .overflow_hidden()
+                .child(bounds_canvas)
+                .child(view.clone().into_any_element()),
+            CenterView::Default => div()
+                .relative()
+                .flex_1()
+                .flex()
+                .flex_row()
+                .overflow_hidden()
+                .child(bounds_canvas)
+                .on_drag_move(cx.listener(Self::handle_dock_drag))
+                .child(self.left_dock.clone())
+                .child(
+                    div()
+                        .flex_1()
+                        .flex()
+                        .flex_col()
+                        .overflow_hidden()
+                        .child(self.render_default_center())
+                        .child(self.bottom_dock.clone()),
+                )
+                .child(self.right_dock.clone()),
+        };
+
         div()
+            .key_context("Workspace")
+            .track_focus(&self.focus_handle)
+            .on_action(cx.listener(Self::toggle_command_palette))
+            .on_action(cx.listener(Self::open_settings))
+            .on_action(cx.listener(Self::close_settings))
+            .relative()
             .size_full()
             .flex()
             .flex_col()
             .bg(theme::background())
             .text_color(theme::text())
             .child(self.title_bar.clone())
-            .child(
-                div()
-                    .relative()
-                    .flex_1()
-                    .flex()
-                    .flex_row()
-                    .overflow_hidden()
-                    .child(bounds_canvas)
-                    .on_drag_move(cx.listener(Self::handle_dock_drag))
-                    .child(self.left_dock.clone())
-                    .child(
-                        div()
-                            .flex_1()
-                            .flex()
-                            .flex_col()
-                            .overflow_hidden()
-                            .child(
-                                div()
-                                    .flex_1()
-                                    .flex()
-                                    .items_center()
-                                    .justify_center()
-                                    .text_color(theme::text_muted())
-                                    .child("Center"),
-                            )
-                            .child(self.bottom_dock.clone()),
-                    )
-                    .child(self.right_dock.clone()),
-            )
+            .child(body)
             .child(self.status_bar.clone())
+            .when_some(palette_overlay, |this, overlay| this.child(overlay))
     }
+}
+
+fn default_commands() -> Vec<Command> {
+    vec![
+        Command {
+            name: "Settings: Open".into(),
+            keybinding: None,
+            action: open_settings_handler(),
+        },
+        Command {
+            name: "Settings: Close".into(),
+            keybinding: None,
+            action: close_settings_handler(),
+        },
+        Command {
+            name: "Workspace: Reset Docks".into(),
+            keybinding: None,
+            action: reset_docks_handler(),
+        },
+    ]
+}
+
+fn open_settings_handler() -> CommandHandler {
+    Box::new(|workspace, window, cx| {
+        workspace.open_settings(&OpenSettings, window, cx);
+    })
+}
+
+fn close_settings_handler() -> CommandHandler {
+    Box::new(|workspace, window, cx| {
+        workspace.close_settings(&CloseSettings, window, cx);
+    })
+}
+
+fn reset_docks_handler() -> CommandHandler {
+    Box::new(|workspace, _, cx| {
+        workspace.left_dock.update(cx, |dock, cx| {
+            dock.set_size(px(240.0));
+            cx.notify();
+        });
+        workspace.right_dock.update(cx, |dock, cx| {
+            dock.set_size(px(240.0));
+            cx.notify();
+        });
+        workspace.bottom_dock.update(cx, |dock, cx| {
+            dock.set_size(px(200.0));
+            cx.notify();
+        });
+    })
 }


### PR DESCRIPTION
## Summary
- Adds a Cmd+K / Ctrl+K command palette modal (`crates/gesttalt/src/command_palette.rs`) with type-to-filter, ↑/↓ navigation, Enter/click to confirm, Esc/backdrop to dismiss.
- Adds a Zed-style two-pane settings view (`crates/gesttalt/src/settings.rs`) reachable from the palette, with sections for General, Appearance, Agents, and Dev Tools. While settings is open it replaces the workspace center between title bar and status bar so docks aren't squeezed.
- Seeds an extensible Dev Tools registry (`crates/gesttalt/src/dev_tools.rs`) with Workspace Bounds, Theme Inspector, Agent Probe, and Keymap Inspector — extend by appending to `default_dev_tools()`.
- Wires Cmd+Q / Ctrl+Q to quit via a registered `Quit` action and a `Gesttalt → Quit Gesttalt` menu item (the GPUI runtime doesn't do this by default).
- Extends CI to also build on `windows-latest` in parallel with the existing Linux build/test job.

## Testing
- `cargo build -p gesttalt`
- `cargo clippy -p gesttalt --all-targets`
- `cargo fmt --all -- --check`
- Smoke test: launched the binary, confirmed it stays alive and renders. Cmd+K → Settings/Dev Tools and Cmd+Q quitting need to be exercised manually on macOS; Windows build will be exercised by CI on this PR.
